### PR TITLE
Fix SWO pin frequency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ swo_trace_clkin_freq = 64000000
 and 
 
 ```py
-  -c "tpiu config internal - uart off 64000000"
+  -c "nucleo_f103rb.tpiu configure -traceclk 64000000"
 ```
 
 clock values. This **must** be the HCLK frequency / CPU frequency that the microcontroller is setup to run with in the firmware.

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,12 +21,22 @@ swo_trace_clkin_freq = 64000000
 ; if you want to see SWO outputs during debugging, a custom
 ; debug server invocation must be used.
 ; adapt interface and target accordingly.
+; this entails changing the traceclk parameter to match
+; the swo_trace_clkin_freq above.
+; the SWO pin frequency param is irrelevant, since we are forwarding to
+; tcl_trace, but OpenOCD will otherwise fail to enable the TPIU.
 ; this is used when starting debugging, not in the SWO Viewer task.
 ; after debugging starts, one must manually start the swo_viewer.py with
 ; python swo_parser.py --dont-run
 debug_server = $PLATFORMIO_CORE_DIR/packages/tool-openocd/bin/openocd
   -f $PLATFORMIO_CORE_DIR/packages/tool-openocd/scripts/interface/stlink.cfg
   -f $PLATFORMIO_CORE_DIR/packages/tool-openocd/scripts/target/stm32f1x.cfg
-  -c "tpiu config internal - uart off 64000000"
+  -c "tpiu create nucleo_f103rb.tpiu -dap nucleo_f103rb.dap -ap-num 0"
+  -c "nucleo_f103rb.tpiu configure -protocol uart"
+  -c "nucleo_f103rb.tpiu configure -output -"
+  -c "nucleo_f103rb.tpiu configure -traceclk 64000000"
+  -c "nucleo_f103rb.tpiu configure -pin-freq 2000000"
+  -c "nucleo_f103rb.tpiu configure -formatter 0"
   -c "itm ports on"
+  -c "nucleo_f103rb.tpiu enable"
   -c "tcl_port 6666"


### PR DESCRIPTION
Hey!

Found this demo pretty useful to help me play around with my ST B-L475E-IOT01A Discovery. The only issue I came across was that running the debug with the current platformio.ini example yields the following error for the SWO pin:

![image](https://user-images.githubusercontent.com/11648759/156166943-a34a0279-1806-46ba-a7a7-3f693afecf23.png)

Also, note the deprecated warnings. I managed to fix these by using the syntax recommended in the [official docs](https://openocd.org/doc/html/Architecture-and-Core-Commands.html).

I changed the platformio.ini to comply with the recommended syntax and, at least on my end, I am not getting any errors or warnings. I can successfully observe the ITM trace via the `swo_parser.py` script after starting the debug session with the correct trace clock value. Unfortunately, the SWO pin frequency is still required even though the docs mention that it can be omitted for the driver to pick up the frequency.

The TPIU enable command also must follow the `itm ports on`, otherwise the TRACE_IOEN will remain 0 and there will be no trace pins assigned. 