### PR TITLE
Support for bluepill board with clone and authentic stm32 chip

### DIFF
--- a/add_swo_viewer.py
+++ b/add_swo_viewer.py
@@ -6,51 +6,70 @@ import sys
 Import("env")
 
 def swo_viewer_task(*args, **kwargs):
-    environ['PYTHONUNBUFFERED'] = '1'
+    environ["PYTHONUNBUFFERED"] = "1"
     print("Entrypoint")
     board = env.BoardConfig()
     platform = env.PioPlatform()
     debug = board.manifest.get("debug", {})
     openocd_path = path.join(platform.get_package_dir("tool-openocd"), "bin", "openocd")
     upload_protocol = env.subst("$UPLOAD_PROTOCOL")
-    #connect_to_openocd_tcl()
-    server_args = [
-        "-s",
-        path.join(platform.get_package_dir("tool-openocd"), "scripts")
-    ]
+    upload_flags = env.subst("$UPLOAD_FLAGS")
+    # connect_to_openocd_tcl()
+    server_args = ["-s", path.join(platform.get_package_dir("tool-openocd"), "scripts")]
     if debug.get("openocd_board"):
-        server_args.extend([
-            "-f", "board/%s.cfg" % debug.get("openocd_board")
-        ])
+        server_args.extend(["-f", "board/%s.cfg" % debug.get("openocd_board")])
     else:
         assert debug.get("openocd_target"), (
-            "Missed target configuration for %s" % board.id)
-        server_args.extend([
-            "-f", "interface/%s.cfg" % upload_protocol,
-            "-c", "transport select %s" % (
-                "hla_swd" if upload_protocol == "stlink" else "swd"),
-            "-f", "target/%s.cfg" % debug.get("openocd_target")
-        ])
+            "Missed target configuration for %s" % board.id
+        )
+
+        if upload_flags:
+            server_args.extend(["%s" % upload_flags])
+
+        server_args.extend(
+            [
+                "-f",
+                "interface/%s.cfg" % upload_protocol,
+                "-c",
+                "transport select %s"
+                % ("hla_swd" if upload_protocol == "stlink" else "swd"),
+                "-f",
+                "target/%s.cfg" % debug.get("openocd_target"),
+            ]
+        )
+
     # per https://openocd.org/doc-release/pdf/openocd.pdf
     # TRACECLKIN_freq: this should be specified to match target's current TRACECLKIN frequency (usually the same as HCLK).
     # trace_freq: trace port frequency. Can be omitted in internal mode to let the adapter driver select the maximum supported rate automatically.
-    swo_trace_clkin_freq = str(env.GetProjectOption("swo_trace_clkin_freq", env.subst("$BOARD_F_CPU")[:-1]))
+    swo_trace_clkin_freq = str(
+        env.GetProjectOption("swo_trace_clkin_freq", env.subst("$BOARD_F_CPU")[:-1])
+    )
     swo_trace_freq = str(env.GetProjectOption("swo_trace_freq", "115200"))
-    server_args.extend([
-        "-c", "init; tpiu config internal - uart false %s %s; itm ports on" % (swo_trace_clkin_freq, swo_trace_freq),
-        #"-c", "reset run" 
-        # SWO parser.py was extended to make target run
-    ])
+    server_args.extend(
+        [
+            "-c",
+            "init; tpiu config internal - uart false %s %s; itm ports on"
+            % (swo_trace_clkin_freq, swo_trace_freq),
+            # "-c", "reset run"
+            # SWO parser.py was extended to make target run
+        ]
+    )
     server_args.insert(0, openocd_path)
-    print("Starting OpenOCD with SWO Trace clock-in frequency %s, SWO trace frequency %s. Invocation:" % (swo_trace_clkin_freq, swo_trace_freq))
+    print(
+        "Starting OpenOCD with SWO Trace clock-in frequency %s, SWO trace frequency %s. Invocation:"
+        % (swo_trace_clkin_freq, swo_trace_freq)
+    )
     print(server_args)
     # start client process in parallel
-    subprocess.Popen([env.subst("$PYTHONEXE"), path.join(env.subst("$PROJECT_DIR"), "swo_parser.py")])
+    subprocess.Popen(
+        [env.subst("$PYTHONEXE"), path.join(env.subst("$PROJECT_DIR"), "swo_parser.py")]
+    )
     # start openocd process parallel but wait in-line
     openocd_process = subprocess.Popen(server_args)
     openocd_process.communicate()
     print("Exited from TCL client")
     sys.exc_clear()
+
 
 env.AddCustomTarget(
     "swo_viewer",
@@ -58,5 +77,5 @@ env.AddCustomTarget(
     swo_viewer_task,
     title="SWO Viewer",
     description="Starts viewing the SWO output",
-    always_build=True
+    always_build=True,
 )

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,9 @@
 [env:nucleo_f103rb]
 platform = ststm32
 board = nucleo_f103rb
-build_flags = -DF1
+build_flags = -DF1 
+  -D NUCLEO_F103RB
+
 framework = stm32cube
 ; add "Custom" -> "SWO Viewer" project task
 extra_scripts = pre:add_swo_viewer.py
@@ -46,6 +48,7 @@ debug_server = $PLATFORMIO_CORE_DIR/packages/tool-openocd/bin/openocd
 platform = ststm32
 board = blackpill_f401cc
 build_flags = -DF4
+  -D BLACKPILL_F401CC
 framework = stm32cube
 debug_tool = stlink
 upload_protocol = stlink
@@ -77,4 +80,87 @@ debug_server = $PLATFORMIO_CORE_DIR/packages/tool-openocd/bin/openocd
   -c "stm32f4x.tpiu configure -formatter 0"
   -c "itm ports on"
   -c "stm32f4x.tpiu enable"
+  -c "tcl_port 6666"
+
+[genericSTM32F103C8]
+platform = ststm32
+board = genericSTM32F103C8
+framework = stm32cube
+build_flags = -D F1
+  -D BLUEPILL_F103C8
+
+board_build.mcu = stm32f103c8t6
+
+; set SWO trace clock in frequency to configured HCLK frequency
+; in this example, board is clocked via HSI to 64MHz.
+; if this number is wrong, there will be no output.
+swo_trace_clkin_freq = 64000000
+
+debug_tool = stlink
+upload_protocol = stlink
+
+[env:bluepill_f103c8]
+extends = genericSTM32F103C8
+
+; if you want to see SWO outputs during debugging, a custom
+; debug server invocation must be used.
+; adapt interface and target accordingly.
+; this entails changing the traceclk parameter to match
+; the swo_trace_clkin_freq above.
+; the SWO pin frequency param is irrelevant, since we are forwarding to
+; tcl_trace, but OpenOCD will otherwise fail to enable the TPIU.
+; this is used when starting debugging, not in the SWO Viewer task.
+; after debugging starts, one must manually start the swo_viewer.py with
+; python swo_parser.py --dont-run
+debug_server = $PLATFORMIO_CORE_DIR/packages/tool-openocd/bin/openocd
+  -s $PLATFORMIO_CORE_DIR/packages/tool-openocd/scripts
+  -f interface/stlink.cfg
+  -c "transport select hla_swd"
+  -f target/stm32f1x.cfg
+  -c "tpiu config internal - uart off 64000000"
+  ; -c "stm32f1x.tpiu configure -protocol uart"
+  ; -c "stm32f1x.tpiu configure -output -"
+  ; -c "stm32f1x.tpiu configure -traceclk 64000000"
+  ; -c "stm32f1x.tpiu configure -pin-freq 2000000"
+  ; -c "stm32f1x.tpiu configure -formatter 0"
+  ; -c "stm32f1x.tpiu enable"
+  -c "itm ports on"
+  -c "tcl_port 6666"
+
+extra_scripts = pre:add_swo_viewer.py
+
+
+[env:clone_bluepill_f103c8]
+extends = genericSTM32F103C8
+
+; add "Custom" -> "SWO Viewer" project task
+extra_scripts = pre:add_swo_viewer.py
+
+; set CPUTAPID to 0x2ba01477 for the clone stm32103 chip
+upload_flags = -c set CPUTAPID 0x2ba01477
+
+; if you want to see SWO outputs during debugging, a custom
+; debug server invocation must be used.
+; adapt interface and target accordingly.
+; this entails changing the traceclk parameter to match
+; the swo_trace_clkin_freq above.
+; the SWO pin frequency param is irrelevant, since we are forwarding to
+; tcl_trace, but OpenOCD will otherwise fail to enable the TPIU.
+; this is used when starting debugging, not in the SWO Viewer task.
+; after debugging starts, one must manually start the swo_viewer.py with
+; python swo_parser.py --dont-run
+debug_server = $PLATFORMIO_CORE_DIR/packages/tool-openocd/bin/openocd
+  -s $PLATFORMIO_CORE_DIR/packages/tool-openocd/scripts
+  -f interface/stlink.cfg
+  -c "transport select hla_swd"
+  -c "set CPUTAPID 0x2ba01477"
+  -f target/stm32f1x.cfg
+  -c "tpiu config internal - uart off 64000000"
+  ; -c "stm32f1x.tpiu configure -protocol uart"
+  ; -c "stm32f1x.tpiu configure -output -"
+  ; -c "stm32f1x.tpiu configure -traceclk 64000000"
+  ; -c "stm32f1x.tpiu configure -pin-freq 2000000"
+  ; -c "stm32f1x.tpiu configure -formatter 0"
+  ; -c "stm32f1x.tpiu enable"
+  -c "itm ports on"
   -c "tcl_port 6666"

--- a/src/main.c
+++ b/src/main.c
@@ -24,14 +24,22 @@
 #include <sys/unistd.h> // STDOUT_FILENO, STDERR_FILENO
 #include <stdio.h>
 
-#if F1
-#define LED_PIN GPIO_PIN_5
-#define LED_GPIO_PORT GPIOA
-#define LED_GPIO_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
-#elif F4
-#define LED_PIN                                GPIO_PIN_13
-#define LED_GPIO_PORT                          GPIOC
-#define LED_GPIO_CLK_ENABLE()                  __HAL_RCC_GPIOC_CLK_ENABLE()
+#if (F1 && NUCLEO_F103RB)
+
+#define LED_PIN                 GPIO_PIN_5
+#define LED_GPIO_PORT           GPIOA
+#define LED_GPIO_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
+
+#elif (F1 && BLUEPILL_F103C8)
+
+#define LED_PIN                 GPIO_PIN_13
+#define LED_GPIO_PORT           GPIOC
+#define LED_GPIO_CLK_ENABLE()   __HAL_RCC_GPIOC_CLK_ENABLE()
+
+#elif (F4 && BLACKPILL_F401CC)
+#define LED_PIN                  GPIO_PIN_13
+#define LED_GPIO_PORT            GPIOC
+#define LED_GPIO_CLK_ENABLE()   __HAL_RCC_GPIOC_CLK_ENABLE()
 #else
 #error "Unsupported STM32 Family for this example"
 #endif
@@ -57,7 +65,7 @@ int main(void)
   printf("SWO test firmware start!\n");
   while (1)
   {
-    static int i=0;
+    static int i = 0;
     printf("Blinky number %d!\n", i++);
     HAL_GPIO_TogglePin(LED_GPIO_PORT, LED_PIN);
     HAL_Delay(1000);
@@ -69,7 +77,7 @@ void SysTick_Handler(void)
   HAL_IncTick();
 }
 
-//overwrite printf() output to send via ITM (SWO)
+// overwrite printf() output to send via ITM (SWO)
 int _write(int file, char *data, int len)
 {
   if ((file != STDOUT_FILENO) && (file != STDERR_FILENO))
@@ -104,7 +112,7 @@ void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLMUL = RCC_PLL_MUL16;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
-    //Error_Handler();
+    // Error_Handler();
   }
 
   /* Initializes the CPU, AHB and APB busses clocks */
@@ -116,14 +124,14 @@ void SystemClock_Config(void)
 
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
   {
-    //Error_Handler();
+    // Error_Handler();
   }
 
   PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC;
   PeriphClkInit.AdcClockSelection = RCC_ADCPCLK2_DIV6;
   if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
   {
-    //Error_Handler();
+    // Error_Handler();
   }
 }
 #elif F4
@@ -133,13 +141,13 @@ void SystemClock_Config(void)
   RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
 
   /** Configure the main internal regulator output voltage
-  */
+   */
   __HAL_RCC_PWR_CLK_ENABLE();
   __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
 
   /** Initializes the RCC Oscillators according to the specified parameters
-  * in the RCC_OscInitTypeDef structure.
-  */
+   * in the RCC_OscInitTypeDef structure.
+   */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
   RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
@@ -150,9 +158,8 @@ void SystemClock_Config(void)
   }
 
   /** Initializes the CPU, AHB and APB buses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
+   */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;


### PR DESCRIPTION
Modified ```platformio.ini``` to add support bluepill boards with clone and authentic stm32 chips and added build flags for the boards.

Added: 
```python 
    upload_flags = env.subst("$UPLOAD_FLAGS")
    if upload_flags:
         server_args.extend(["%s" % upload_flags])
``` 
 to ```add_swo_viewer.py```  to use upload_flags.